### PR TITLE
added flexible filters object to custom_dump; added legacy pk list funct...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,12 @@ Usage
 There are four commands.  ``dump_object`` returns the json representation of
 a specific object as well as all its dependencies (as defined by ForeignKeys).
 
-    ./manage.py dump_object APP.MODEL '{"pk__in": [PK1, PK2, PK3]}' > my_new_fixture.json
+    ./manage.py dump_object APP.MODEL PK1 PK2 PK3 ... > my_new_fixture.json
+
+Or if you need more control over your filter parameters, you can pass a json
+object
+
+    ./manage.py dump_object APP.MODEL '{"myfield__in": [value1, value2, value3]}' > my_new_fixture.json
 
 Or you can get all objects with all dependencies by passing an asterisk:
 


### PR DESCRIPTION
...ionality back

I like the flexibility provided by passing an object as a filter parameter, but I have some old scripts that use the primary keys as parameters, so I added that functionality back.

Also, custom_dump was not updated to work with objects and was still taking PKs.
